### PR TITLE
Add a skipped model association cleanup test

### DIFF
--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -6,4 +6,8 @@ class BookTest < ActiveSupport::TestCase
     assert_not book.save
     assert_equal [:title, :author], book.errors.as_json.keys
   end
+
+  test "book removes all linked reviews on destroy" do
+    skip "TODO: need to implement the association cleanup"
+  end
 end


### PR DESCRIPTION
Add an example skipped test that might be pursued after the suite is green.