### PR TITLE
remove gem_cache volume from docker compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     image: better_reads:latest
     volumes:
       - .:/rails
-      - gem_cache:/usr/local/bundle
     ports:
       - "3000:3000"
   tailwind:
@@ -15,7 +14,3 @@ services:
     command: "tailwind-compose"
     volumes:
       - .:/rails
-      - gem_cache:/usr/local/bundle
-
-volumes:
-  gem_cache:


### PR DESCRIPTION
The gem_cache volume can save time but it complicates dependency updates. Instead we shall remove it and let folks can just pay the image rebuild cost when the gemfile changes.